### PR TITLE
Minor patches about pip installation and dataset indexing

### DIFF
--- a/mocapact/distillation/dataset.py
+++ b/mocapact/distillation/dataset.py
@@ -317,7 +317,7 @@ class ExpertDataset(Dataset):
         TODO
         """
         if idx >= len(self):
-            raise IndexError("dataset index out of range")
+            raise IndexError("Dataset index out of range")
 
         dset_idx = bisect.bisect_right(self._dset_indices, idx)-1
 

--- a/mocapact/distillation/dataset.py
+++ b/mocapact/distillation/dataset.py
@@ -316,6 +316,9 @@ class ExpertDataset(Dataset):
         """
         TODO
         """
+        if idx >= len(self):
+            raise IndexError("dataset index out of range")
+
         dset_idx = bisect.bisect_right(self._dset_indices, idx)-1
 
         if self._keep_hdf5s_open:

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,5 @@
 from distutils.core import setup
+from setuptools import find_packages
 
 setup(
     name='mocapact',
@@ -6,7 +7,7 @@ setup(
     author='Nolan Wagener',
     author_email='nolan.wagener@gatech.edu',
     license='MIT',
-    packages=['mocapact'],
+    packages=find_packages(),
     install_requires=[
         'azure.storage.blob==12.9.0',
         'cloudpickle>=2.1.0',


### PR DESCRIPTION
Two minor patches:
1. A simple change to `setup.py` to use `find_packages()`. The current code works fine when installing locally with `pip install -e .`. However, all the subpackages, e.g. mocapact.distillation, mocapact.offline_rl etc. would not be missing when installing through pip install git+https://github.com/microsoft/MoCapAct.git. To reproduce this
```
pip install git+https://github.com/microsoft/MoCapAct.git
ls [What you get from python -c "import mocapact; print(mocapact.__path__[0])"]
```
You will find that the folders are missing from the installation.

2. Raise an `IndexError` in `mocapact.distillation.dataset.ExpertDataset` when using `idx >= len(dataset)`. In the current code, an index error would not be properly raised when `dataset.is_sequential == True`. The is because a weird “feature” of range indexing for python sequential objects using colon in general. For non-sequential datasets, it is working “fine” as an index error can be properly raised for illegal queries. For example, within python
```
a = [1, 2, 3]
# No error is raised with this
print(a[2:10])
# IndexError here
print(a[9])
```
Therefore, one is actually able to access “illegal” indices of `ExpertDataset` when `is_sequential == True` (since it uses range indexing rather than direct indexing). Here is a sample code
```
from mocapact.distillation.dataset import ExpertDataset
from mocapact.observables import HIGH_LEVEL_OBSERVABLES_SANS_REFERENCE

"""
First download hdf5 files through
python -m mocapact.download_dataset -t small_dataset -c CMU_001_01 -d ./data
"""
hdf5_fnames = ['./data/dataset/small/CMU_001_01.hdf5']
metrics_path = './data/dataset/small/dataset_metrics.npz'
dataset = ExpertDataset(hdf5_fnames=hdf5_fnames,
                        observables=HIGH_LEVEL_OBSERVABLES_SANS_REFERENCE,
                        metrics_path=metrics_path,
                        max_seq_steps=10,
                        min_seq_steps=10)
# Check out the length of dataset
print("Dataset length:", len(dataset))
print("")

# We first print the size of first tuple in dataset
# which is totally normal
print(f"Accessing dataset[0]")
state, action, _ = dataset[0]
print("\tState shape", state.shape)
print("\tAction shape", action.shape)
print("")

# We now print out dataset[len(dataset)]
# all the way to dataset[len(dataset)+11].
# Surprisingly, we can still get those values
# (normally we would expect to get an IndexError)
# Moreover, the shape of state and action is not
# the same as dataset[0]
for i in range(11):
    print(f"Accessing dataset[{len(dataset)+i}]")
    state, action, _ = dataset[len(dataset)+I]
    print("\tState shape", state.shape)
    print("\tAction shape", action.shape)
    print("")
```
With the fix in this PR, an `IndexError` would be raised in the last block of code.

Although `torch.data.DataLoader` works fine since `len(dataset)` is properly defined. This indexing issue would cause problem for the python native iterator. Basically, `iter(dataset)` won’t stop properly, as it expects `IndexError` to give it the signal of stopping the loop. (Interestingly, native python iterator does not look at `__len__`. ) For example, this does not properly loop through the dataset. It goes beyond `len(dataset)` until errors out at `dataset[len(dataset)+11]`.
```
# The following loop does not stop at len(dataset) - 1.
# It actually goes all the way to len(dataset) + 11
# when there is an error computing the weights, which
# is a ones array with a negative size
from tqdm import tqdm
for data in tqdm(dataset):
    pass
```
With the fix of raising `IndexError`, the above block of code should loop through the dataset once and does not raise any errors.