### PR TITLE
Unpin gym==0.21

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ setup(
         'azure.storage.blob==12.9.0',
         'cloudpickle>=2.1.0',
         'dm_control>=1.0.7',
-        'gym==0.21',
+        'gym<0.24',
         'h5py',
         'imageio',
         'imageio-ffmpeg',


### PR DESCRIPTION
gym==0.21 contains a typo (see https://github.com/openai/gym/commit/9180d12e1b66e7e2a1a622614f787a6ec147ac40)

I think any version below between gym 21 and 23 should still be compatible with MoCapAct as gym23 is the last version of gym that uses the old step API.